### PR TITLE
fix(bag): use decode_headerless instead of decode_ros1 for BAG messages

### DIFF
--- a/src/io/formats/bag/parallel.rs
+++ b/src/io/formats/bag/parallel.rs
@@ -624,9 +624,10 @@ impl<'a> Iterator for BagDecodedMessageStream<'a> {
                 Err(e) => return Some(Err(e)),
             };
 
-            // Use decode_ros1 which handles the ROS1-specific CDR format
-            // (no CDR header, little-endian)
-            match self.decoder.decode_ros1(
+            // Use decode_headerless for ROS1 bag messages
+            // The BAG parser extracts just the CDR message data (without wrapper headers),
+            // so we need to decode from byte 0, not skip 16 bytes like decode_ros1 does.
+            match self.decoder.decode_headerless(
                 &parsed_schema,
                 &raw_msg.data,
                 Some(&channel_info.message_type),


### PR DESCRIPTION
## Summary

Fixes #26 - BAG decoder was failing to handle `kuavo_msgs/sensorsData` messages with error:
```
Array length 656114711 exceeds maximum allowed 10000000
```

## Root Cause

The BAG parser's `read_record` function extracts just the CDR-encoded message data from BAG records, without any wrapper headers. However, `decode_ros1` was designed to expect a 16-byte header (12-byte ROS record header + 4-byte CDR header) and skips those bytes.

When `decode_ros1` skips 16 bytes of actual message data, it causes misalignment during decoding. This leads to corrupted values being read as array lengths (e.g., 656114711 instead of a valid array size).

## Fix

Changed `BagDecodedMessageStream::next()` to use `decode_headerless()` instead of `decode_ros1()`. The `decode_headerless()` method processes the message data from byte 0 without skipping any header bytes, which is correct for the data format returned by the BAG parser.

## Test Plan

- [x] All existing tests pass (`cargo test`)
- [x] Format and lint checks pass (`make check`)
- [x] Verified against problematic BAG file that previously failed